### PR TITLE
fix(ci): Remove verification action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,11 +81,6 @@ jobs:
           echo "BASE_IMAGE_URL=$BASE_IMAGE" >> $GITHUB_ENV
           echo "BASE_IMAGE_NAME=$(echo $BASE_IMAGE | sed 's/.*\/.*\///')" >> $GITHUB_ENV
 
-      - name: Verify base image
-        uses: EyeCantCU/cosign-action/verify@v0.2.1
-        with:
-          containers: ${{ env.BASE_IMAGE_NAME }}:${{ env.IMAGE_MAJOR_VERSION }}
-
       - name: Get current version
         id: labels
         run: |


### PR DESCRIPTION
Fedora doesn't currently sign their images with sigstore