### PR TITLE
fix(signing): Ensure target directory exists before copying key

### DIFF
--- a/config/scripts/signing.sh
+++ b/config/scripts/signing.sh
@@ -6,6 +6,7 @@ set -oue pipefail
 echo "Setting up container signing in policy.json and cosign.yaml for $IMAGE_NAME"
 echo "Registry to write: $IMAGE_REGISTRY"
 
+mkdir -p /usr/etc/pki/containers/
 cp /usr/share/ublue-os/cosign.pub /usr/etc/pki/containers/"$IMAGE_NAME".pub
 
 FILE=/usr/etc/containers/policy.json


### PR DESCRIPTION
Creates target for signing key if it does not exist